### PR TITLE
Add .env.example file for reference

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,39 @@
+# Example environment variables for LagBuy Backend
+# Copy this file to `.env` and fill in real secrets. DO NOT commit real secrets to source control.
+
+# Application Settings
+SECRET_KEY="your-secret-key-here"
+DEBUG="False"
+DJANGO_SETTINGS_MODULE="lagbuy.settings"
+
+# Django Superuser Settings (used by manage.py createsuperuser --noinput)
+DJANGO_SUPERUSER_EMAIL="admin@example.com"
+DJANGO_SUPERUSER_FIRST_NAME="Admin"
+DJANGO_SUPERUSER_LAST_NAME="User"
+DJANGO_SUPERUSER_PASSWORD="changeme"
+DJANGO_SUPERUSER_PHONE_NUMBER="08000000000"
+
+# AWS S3 Settings (if using S3 storage)
+AWS_ACCESS_KEY_ID="YOUR_AWS_ACCESS_KEY_ID"
+AWS_SECRET_ACCESS_KEY="YOUR_AWS_SECRET_ACCESS_KEY"
+AWS_STORAGE_BUCKET_NAME="your-bucket-name"
+AWS_S3_REGION_NAME="us-east-1"
+
+# Database Settings
+RDS_USERNAME="db_user"
+RDS_PASSWORD="db_password"
+DB_NAME="lagbuydb"
+RDS_HOSTNAME="localhost"
+RDS_PORT="5432"
+
+# Email Settings
+EMAIL_HOST_USER="your-email@example.com"
+SENDGRID_API_KEY="YOUR_SENDGRID_API_KEY"
+
+# Paystack / Payment Gateway Settings
+# Use test or live keys depending on environment
+PAYSTACK_TEST_SECRET_KEY="your-paystack-secret-key"
+
+# Optional local overrides:
+# PRIORITY_WITHDRAWAL_FEE_FLAT=500.00
+# PAYSTACK_BASE_URL=https://api.paystack.co


### PR DESCRIPTION
Introduce an example environment variables file to guide users in setting up their own `.env` file without exposing real secrets.